### PR TITLE
fix: natural sort tags on output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,6 +1078,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "natord"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,7 +1409,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "regskin"
-version = "1.3.1"
+version = "1.3.3"
 dependencies = [
  "actix-files",
  "actix-web",
@@ -1413,6 +1419,7 @@ dependencies = [
  "env_logger",
  "lazy_static",
  "log",
+ "natord",
  "quote 1.0.35",
  "rand 0.7.3",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regskin"
-version = "1.3.2"
+version = "1.3.3"
 authors = ["rabadin <rvbadin@gmail.com>"]
 edition = "2021"
 
@@ -24,3 +24,4 @@ rand = "0.7"
 reqwest = { version = "0.11", features = ["json", "blocking", "gzip"] }
 askama = "0.12"
 bytes = "0.4"
+natord = "1.0.9"

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -164,8 +164,7 @@ impl Catalog {
             return Ok(Tags::new());
         } else if response.status().is_success() {
             let mut tags: Tags = response.json().await?;
-            tags.tags.sort();
-            tags.tags.reverse();
+            tags.tags.sort_by(|a, b| natord::compare(&b, &a));  // natural sort, descending 
             return Ok(tags);
         }
         Ok(Tags::new())


### PR DESCRIPTION
This should present semantic versions in a much nicer way.